### PR TITLE
Code changes post initial implementations SDK-5036

### DIFF
--- a/clevertap-android-vault-sdk/src/main/java/com/clevertap/android/vault/sdk/api/TokenizationApi.kt
+++ b/clevertap-android-vault-sdk/src/main/java/com/clevertap/android/vault/sdk/api/TokenizationApi.kt
@@ -81,7 +81,7 @@ interface TokenizationApi {
     @POST("api/tokenization/getToken")
     suspend fun tokenizeEncrypted(
         @Header("Authorization") authorization: String,
-        @Header("X-Clevertap-Encryption-Enabled") encryptionEnabled: Boolean = true,
+        @Header("Encrypted") encryptionEnabled: Boolean = true,
         @Body request: EncryptedRequest
     ): Response<EncryptedResponse>
 
@@ -95,7 +95,7 @@ interface TokenizationApi {
     @POST("api/tokenization/getRawValue")
     suspend fun detokenizeEncrypted(
         @Header("Authorization") authorization: String,
-        @Header("X-Clevertap-Encryption-Enabled") encryptionEnabled: Boolean = true,
+        @Header("Encrypted") encryptionEnabled: Boolean = true,
         @Body request: EncryptedRequest
     ): Response<EncryptedResponse>
 
@@ -109,7 +109,7 @@ interface TokenizationApi {
     @POST("api/tokenization/tokens/batch")
     suspend fun batchTokenizeEncrypted(
         @Header("Authorization") authorization: String,
-        @Header("X-Clevertap-Encryption-Enabled") encryptionEnabled: Boolean = true,
+        @Header("Encrypted") encryptionEnabled: Boolean = true,
         @Body request: EncryptedRequest
     ): Response<EncryptedResponse>
 
@@ -123,7 +123,7 @@ interface TokenizationApi {
     @POST("api/tokenization/tokens/values/batch")
     suspend fun batchDetokenizeEncrypted(
         @Header("Authorization") authorization: String,
-        @Header("X-Clevertap-Encryption-Enabled") encryptionEnabled: Boolean = true,
+        @Header("Encrypted") encryptionEnabled: Boolean = true,
         @Body request: EncryptedRequest
     ): Response<EncryptedResponse>
 }

--- a/clevertap-android-vault-sdk/src/main/java/com/clevertap/android/vault/sdk/model/ApiModels.kt
+++ b/clevertap-android-vault-sdk/src/main/java/com/clevertap/android/vault/sdk/model/ApiModels.kt
@@ -112,13 +112,13 @@ data class BatchDetokenizeSummary(
 data class EncryptedRequest(
     val itp: String,
     val itk: String,
-    val iv: String
+    val itv: String
 )
 
 /**
  * Encrypted response model
  */
 data class EncryptedResponse(
-    val encryptedPayload: String,
-    val iv: String
+    val itp: String,
+    val itv: String
 )

--- a/clevertap-android-vault-sdk/src/main/java/com/clevertap/android/vault/sdk/repository/TokenRepositoryImpl.kt
+++ b/clevertap-android-vault-sdk/src/main/java/com/clevertap/android/vault/sdk/repository/TokenRepositoryImpl.kt
@@ -453,7 +453,7 @@ class TokenRepositoryImpl(
             val encryptedRequest = EncryptedRequest(
                 itp = encryptionResult.encryptedPayload,
                 itk = encryptionResult.sessionKey,
-                iv = encryptionResult.iv
+                itv = encryptionResult.iv
             )
 
             val response = executeWithRetryForEncryption(
@@ -557,7 +557,7 @@ class TokenRepositoryImpl(
             val encryptedRequest = EncryptedRequest(
                 itp = encryptionResult.encryptedPayload,
                 itk = encryptionResult.sessionKey,
-                iv = encryptionResult.iv
+                itv = encryptionResult.iv
             )
 
             val response = executeWithRetryForEncryption(
@@ -698,7 +698,7 @@ class TokenRepositoryImpl(
             val encryptedRequest = EncryptedRequest(
                 itp = encryptionResult.encryptedPayload,
                 itk = encryptionResult.sessionKey,
-                iv = encryptionResult.iv
+                itv = encryptionResult.iv
             )
 
             val response = executeWithRetryForEncryption(
@@ -849,7 +849,7 @@ class TokenRepositoryImpl(
             val encryptedRequest = EncryptedRequest(
                 itp = encryptionResult.encryptedPayload,
                 itk = encryptionResult.sessionKey,
-                iv = encryptionResult.iv
+                itv = encryptionResult.iv
             )
 
             val response = executeWithRetryForEncryption(
@@ -954,8 +954,8 @@ class TokenRepositoryImpl(
                         if (response.isSuccessful && response.body() != null) {
                             val encryptedResponse = response.body()!!
                             return EncryptedApiResponse(
-                                encryptedResponse.encryptedPayload,
-                                encryptedResponse.iv
+                                encryptedResponse.itp,
+                                encryptedResponse.itv
                             )
                         } else {
                             val errorBody = response.errorBody()?.string() ?: "Unknown error"


### PR DESCRIPTION
Depends on PR #7 

1. BE sends error code 419 due to decryption failure, fallback to tokenization operations without encryption over transit for 419 error
2. change header from `"X-Clevertap-Encryption-Enabled"` to `"Encrypted"`, change keys from `"encryptedPayload"` to `"itp"` and `"iv"` to `"itv" `

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic fallback to non-encrypted requests when encrypted calls fail, including batch operations.
  - Enhanced retry/backoff and token refresh handling for more resilient requests.
- Changes
  - HTTP header for encrypted requests updated to “Encrypted” (was “X-Clevertap-Encryption-Enabled”).
  - Encrypted payload fields renamed: iv → itv; encryptedPayload → itp.
  - Request/response models updated accordingly; adjust integrations to use the new field names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->