### PR TITLE
Pluggable RetryPolicy Interface for ZeroPii SDK SDK-5582

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ CleverTap ZeroPii SDK provides a secure way to tokenize Personally Identifiable 
 
 ## Features
 
-- **Tokenization & Detokenization**: Replace sensitive data with format-preserving tokens and retrieve original values when needed
-- **Batch Operations**: Efficiently process multiple values at once
-- **Secure Authentication**: OAuth2 client credentials flow
-- **Encryption in Transit**: API request and response payloads are encrypted while being transmitted over the network
-- **In-Memory Caching**: Improve performance by caching token mappings
+- **Tokenization**: Replace sensitive data with format-preserving tokens
+- **Batch Operations**: Efficiently tokenize multiple values at once (up to 1,000 per batch)
+- **Pluggable Authentication**: Bring your own token provider via the `AccessTokenProvider` interface
+- **Encryption in Transit**: API request and response payloads are encrypted using AES-256-GCM
+- **Pluggable Retry Policy**: Customize retry behavior or use the built-in exponential backoff
 
 ## Requirements
 
@@ -47,7 +47,27 @@ dependencies {
 
 ## Quick Start
 
-### 1. Initialize the SDK
+### 1. Implement AccessTokenProvider
+
+The SDK requires you to supply access tokens via the `AccessTokenProvider` interface. This gives you full control over how tokens are fetched (OAuth2, custom auth, etc.):
+
+```kotlin
+class MyTokenProvider : AccessTokenProvider {
+    override fun fetchToken(callback: AccessTokenCallback) {
+        // Fetch token from your auth server
+        // Call exactly ONE of onSuccess or onFailure
+        try {
+            val token = "..." // your token fetching logic
+            val expiresIn = 3600L // token lifetime in seconds
+            callback.onSuccess(AccessTokenInfo(token, expiresIn))
+        } catch (e: Exception) {
+            callback.onFailure(e)
+        }
+    }
+}
+```
+
+### 2. Initialize the SDK
 
 Initialize the SDK in your `Application` class:
 
@@ -55,22 +75,18 @@ Initialize the SDK in your `Application` class:
 class MyApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        
+
         // Initialize with minimum required parameters
         ZeroPiiSDK.initialize(
-            clientId = "YOUR_CLIENT_ID",
-            clientSecret = "YOUR_CLIENT_SECRET", 
-            apiUrl = "YOUR_API_URL",
-            authUrl = "YOUR_AUTH_URL"
+            tokenProvider = MyTokenProvider(),
+            apiUrl = "YOUR_API_URL"
         )
-        
+
         // Or with custom log level
         ZeroPiiSDK.initialize(
-            clientId = "YOUR_CLIENT_ID",
-            clientSecret = "YOUR_CLIENT_SECRET",
+            tokenProvider = MyTokenProvider(),
             apiUrl = "YOUR_API_URL",
-            authUrl = "YOUR_AUTH_URL",
-            logLevel = ZeroPiiLogger.LogLevel.DEBUG // Optional
+            logLevel = ZeroPiiLogger.LogLevel.DEBUG
         )
     }
 }
@@ -78,18 +94,18 @@ class MyApplication : Application() {
 
 > **Note**: You **must** call `initialize()` before using any other SDK methods. Calling `getInstance()` before initialization will throw `IllegalStateException`.
 
-### 2. Basic Tokenization
+### 3. Basic Tokenization
 
 ```kotlin
 class MainActivity : AppCompatActivity() {
     private lateinit var zeroPiiSDK: ZeroPiiSDK
-    
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        
+
         // Get SDK instance (after initialization)
         zeroPiiSDK = ZeroPiiSDK.getInstance()
-        
+
         // Tokenize sensitive data
         zeroPiiSDK.tokenize("555-12-3456") { result ->
             when (result) {
@@ -109,30 +125,13 @@ class MainActivity : AppCompatActivity() {
 }
 ```
 
-### 3. Basic Detokenization
-
-```kotlin
-zeroPiiSDK.deTokenizeAsString("555-67-8901") { result ->
-    when (result) {
-        is DetokenizeResult.Success -> {
-            val originalValue:String = result.value
-            val exists = result.exists
-            Log.d("ZeroPiiSDK", "Original value: $originalValue")
-        }
-        is DetokenizeResult.Error -> {
-            Log.e("ZeroPiiSDK", "Detokenization failed: ${result.message}")
-        }
-    }
-}
-```
-
 ### 4. Batch Tokenization
 
 ```kotlin
 // Tokenize multiple sensitive values at once
 val sensitiveData = listOf(
     "555-12-3456",
-    "555-98-7654", 
+    "555-98-7654",
     "555-11-2233",
     "555-44-5566"
 )
@@ -144,7 +143,7 @@ zeroPiiSDK.batchTokenizeStringValues(sensitiveData) { result ->
             Log.d("ZeroPiiSDK", "Processed: ${summary.processedCount}")
             Log.d("ZeroPiiSDK", "New tokens: ${summary.newlyCreatedCount}")
             Log.d("ZeroPiiSDK", "Existing tokens: ${summary.existingCount}")
-            
+
             // Access individual results
             result.results.forEach { item ->
                 Log.d("ZeroPiiSDK", "${item.originalValue} -> ${item.token}")
@@ -157,46 +156,11 @@ zeroPiiSDK.batchTokenizeStringValues(sensitiveData) { result ->
 }
 ```
 
-### 5. Batch Detokenization
-
-```kotlin
-// Detokenize multiple tokens at once
-val tokens = listOf(
-    "TKN_555123456_001",
-    "TKN_555987654_002",
-    "TKN_555112233_003",
-    "TKN_555445566_004"
-)
-
-zeroPiiSDK.batchDeTokenizeAsString(tokens) { result ->
-    when (result) {
-        is BatchDetokenizeResult.Success -> {
-            val summary = result.summary
-            Log.d("ZeroPiiSDK", "Processed: ${summary.processedCount}")
-            Log.d("ZeroPiiSDK", "Found: ${summary.foundCount}")
-            Log.d("ZeroPiiSDK", "Not found: ${summary.notFoundCount}")
-            
-            // Access individual results
-            result.results.forEach { item ->
-                if (item.exists) {
-                    Log.d("ZeroPiiSDK", "${item.token} -> ${item.value}")
-                } else {
-                    Log.d("ZeroPiiSDK", "${item.token} -> Not found")
-                }
-            }
-        }
-        is BatchDetokenizeResult.Error -> {
-            Log.e("ZeroPiiSDK", "Batch detokenization failed: ${result.message}")
-        }
-    }
-}
-```
-
 ### **Note:**
 
-- All tokenize/de-tokenize SDK APIs execute on background threads
-- Callbacks are delivered on the main thread - Safe to update UI directly from callbacks
-- *Batch Size Limits:* For tokenization, maximum 1,000 values per batch and for detokenization, maximum 10,000 tokens per batch
+- All SDK APIs execute on background threads
+- Callbacks are delivered on the main thread — safe to update UI directly from callbacks
+- *Batch Size Limit:* Maximum 1,000 values per batch
 
 ---
 
@@ -208,20 +172,18 @@ zeroPiiSDK.batchDeTokenizeAsString(tokens) { result ->
 
 ```kotlin
 fun initialize(
-    clientId: String,
-    clientSecret: String, 
+    tokenProvider: AccessTokenProvider,
     apiUrl: String,
-    authUrl: String,
-    logLevel: ZeroPiiLogger.LogLevel = ZeroPiiLogger.LogLevel.OFF
+    logLevel: ZeroPiiLogger.LogLevel = ZeroPiiLogger.LogLevel.OFF,
+    retryPolicy: RetryPolicy = /* default exponential backoff policy */
 ): ZeroPiiSDK
 ```
 
 **Parameters:**
-- `clientId` - Your OAuth2 client ID
-- `clientSecret` - Your OAuth2 client secret
-- `apiUrl` - Base URL for tokenization API
-- `authUrl` - Base URL for authentication API
-- `logLevel` - Logging verbosity level (optional)
+- `tokenProvider` - Your implementation of `AccessTokenProvider` that supplies access tokens
+- `apiUrl` - Base URL for the tokenization API
+- `logLevel` - Logging verbosity level (optional, defaults to `OFF`)
+- `retryPolicy` - Custom retry policy (optional, defaults to built-in exponential backoff policy)
 
 #### `getInstance()`
 
@@ -231,17 +193,104 @@ fun getInstance(): ZeroPiiSDK
 
 Returns the initialized SDK instance. Throws `IllegalStateException` if called before `initialize()`.
 
-### Single Value Operations
+### Authentication
 
-#### Tokenization Methods
+#### `AccessTokenProvider`
 
 ```kotlin
-// String tokenization  
+interface AccessTokenProvider {
+    fun fetchToken(callback: AccessTokenCallback)
+}
+```
+
+Implement this interface to supply access tokens to the SDK. The SDK calls `fetchToken` when it needs a token (first request, token expired, or after a 401 response).
+
+#### `AccessTokenCallback`
+
+```kotlin
+interface AccessTokenCallback {
+    fun onSuccess(tokenInfo: AccessTokenInfo)
+    fun onFailure(error: Exception)
+}
+```
+
+Call exactly **one** of `onSuccess` or `onFailure` in your `fetchToken` implementation.
+
+#### `AccessTokenInfo`
+
+```kotlin
+data class AccessTokenInfo(
+    val token: String,
+    val expiresInSeconds: Long
+)
+```
+
+- `token` - The access token string (e.g., a Bearer token)
+- `expiresInSeconds` - Token lifetime in seconds from now
+
+### Retry Policy
+
+#### `RetryPolicy`
+
+```kotlin
+interface RetryPolicy {
+    fun shouldRetry(attempt: Int, httpStatusCode: Int?): Boolean
+    fun retryDelayMs(attempt: Int): Long
+}
+```
+
+Implement this interface to customize retry behavior.
+
+- `shouldRetry` - Called after a failed request. `attempt` is 0-based (0 = after first failure). `httpStatusCode` is `null` for network errors (timeout, no connectivity).
+- `retryDelayMs` - Delay in milliseconds before the retry attempt.
+
+> **Note**: 401 Unauthorized responses bypass `RetryPolicy` entirely — the SDK automatically refreshes the token and retries immediately.
+
+#### Default Behavior
+
+If no custom `retryPolicy` is provided, the SDK uses a built-in exponential backoff policy:
+- Retries on server errors (500, 502, 503, 504), rate limiting (429), and network errors
+- Does not retry on client errors (4xx except 401)
+- Exponential backoff delays: 2s, 4s, 8s, ...
+- Maximum 1 retry by default
+
+#### Custom Retry Policy Example
+
+Here's an example of a linear retry policy that retries up to 3 times with a fixed 2-second delay:
+
+```kotlin
+class LinearRetryPolicy(private val maxRetries: Int = 3) : RetryPolicy {
+
+    private val retryableStatusCodes = setOf(500, 502, 503, 504, 429)
+
+    override fun shouldRetry(attempt: Int, httpStatusCode: Int?): Boolean {
+        if (attempt >= maxRetries) return false
+        // Retry on network errors (null) or server errors
+        return httpStatusCode == null || httpStatusCode in retryableStatusCodes
+    }
+
+    override fun retryDelayMs(attempt: Int): Long {
+        return 2000L // Fixed 2-second delay
+    }
+}
+
+// Use it during initialization
+ZeroPiiSDK.initialize(
+    tokenProvider = MyTokenProvider(),
+    apiUrl = "YOUR_API_URL",
+    retryPolicy = LinearRetryPolicy(maxRetries = 3)
+)
+```
+
+### Single Value Tokenization
+
+```kotlin
+// String tokenization
 fun tokenize(value: String, callback: (TokenizeResult) -> Unit)
 
 // Numeric tokenization
 fun tokenize(value: Int, callback: (TokenizeResult) -> Unit)
-fun tokenize(value: Long, callback: (TokenizeResult) -> Unit) 
+fun tokenize(value: Long, callback: (TokenizeResult) -> Unit)
 fun tokenize(value: Float, callback: (TokenizeResult) -> Unit)
 fun tokenize(value: Double, callback: (TokenizeResult) -> Unit)
 
@@ -249,54 +298,33 @@ fun tokenize(value: Double, callback: (TokenizeResult) -> Unit)
 fun tokenize(value: Boolean, callback: (TokenizeResult) -> Unit)
 ```
 
-#### Detokenization Methods
+### Batch Tokenization
 
 ```kotlin
-// Type-specific detokenization
-fun deTokenizeAsString(token: String, callback: (DetokenizeResult<String>) -> Unit)
-fun deTokenizeAsInt(token: String, callback: (DetokenizeResult<Int>) -> Unit)
-fun deTokenizeAsLong(token: String, callback: (DetokenizeResult<Long>) -> Unit)
-fun deTokenizeAsFloat(token: String, callback: (DetokenizeResult<Float>) -> Unit)
-fun deTokenizeAsDouble(token: String, callback: (DetokenizeResult<Double>) -> Unit) 
-fun deTokenizeAsBoolean(token: String, callback: (DetokenizeResult<Boolean>) -> Unit)
-```
-
-### Batch Operations
-
-#### Batch Tokenization
-
-```kotlin
-// Type-specific batch tokenization
 fun batchTokenizeStringValues(values: List<String>, callback: (BatchTokenizeResult) -> Unit)
 fun batchTokenizeIntValues(values: List<Int>, callback: (BatchTokenizeResult) -> Unit)
 fun batchTokenizeLongValues(values: List<Long>, callback: (BatchTokenizeResult) -> Unit)
-fun batchTokenizeFloatValues(values: List<Float>, callback: (BatchTokenizeResult) -> Unit)  
+fun batchTokenizeFloatValues(values: List<Float>, callback: (BatchTokenizeResult) -> Unit)
 fun batchTokenizeDoubleValues(values: List<Double>, callback: (BatchTokenizeResult) -> Unit)
 fun batchTokenizeBooleanValues(values: List<Boolean>, callback: (BatchTokenizeResult) -> Unit)
-```
-
-#### Batch Detokenization
-
-```kotlin
-// Type-specific batch detokenization
-fun batchDeTokenizeAsString(tokens: List<String>, callback: (BatchDetokenizeResult<String>) -> Unit)
-fun batchDeTokenizeAsInt(tokens: List<String>, callback: (BatchDetokenizeResult<Int>) -> Unit)
-fun batchDeTokenizeAsLong(tokens: List<String>, callback: (BatchDetokenizeResult<Long>) -> Unit)
-fun batchDeTokenizeAsFloat(tokens: List<String>, callback: (BatchDetokenizeResult<Float>) -> Unit)
-fun batchDeTokenizeAsDouble(tokens: List<String>, callback: (BatchDetokenizeResult<Double>) -> Unit)
-fun batchDeTokenizeAsBoolean(tokens: List<String>, callback: (BatchDetokenizeResult<Boolean>) -> Unit)
-```
-
-### Utility Methods
-
-```kotlin
-// Clear token cache
-fun clearCache()
 ```
 
 ---
 
 ## Data Types
+
+### Supported Types
+
+The SDK supports tokenization of the following data types:
+
+| Type | Single | Batch |
+|------|--------|-------|
+| `String` | `tokenize(value: String, ...)` | `batchTokenizeStringValues(...)` |
+| `Int` | `tokenize(value: Int, ...)` | `batchTokenizeIntValues(...)` |
+| `Long` | `tokenize(value: Long, ...)` | `batchTokenizeLongValues(...)` |
+| `Float` | `tokenize(value: Float, ...)` | `batchTokenizeFloatValues(...)` |
+| `Double` | `tokenize(value: Double, ...)` | `batchTokenizeDoubleValues(...)` |
+| `Boolean` | `tokenize(value: Boolean, ...)` | `batchTokenizeBooleanValues(...)` |
 
 ### Result Classes
 
@@ -305,31 +333,16 @@ fun clearCache()
 ```kotlin
 sealed class TokenizeResult {
     data class Success(
-        val token: String,        // Generated token
-        val exists: Boolean,      // Token already existed
-        val newlyCreated: Boolean,// Token was newly created
-        val dataType: String?     // "string" or "number"
+        val token: String,         // Generated token
+        val exists: Boolean,       // Token already existed
+        val newlyCreated: Boolean, // Token was newly created
+        val dataType: String?      // "string" or "number"
     ) : TokenizeResult()
-    
+
     data class Error(
-        val message: String       // Error description
+        val message: String,       // Error description
+        val httpStatusCode: Int?   // HTTP status code (null for network/SDK errors)
     ) : TokenizeResult()
-}
-```
-
-#### `DetokenizeResult<T>`
-
-```kotlin
-sealed class DetokenizeResult<T> {
-    data class Success<T>(
-        val value: T?,           // Original value
-        val exists: Boolean,     // Token exists in system
-        val dataType: String?    // "string" or "number"  
-    ) : DetokenizeResult<T>()
-    
-    data class Error<T>(
-        val message: String      // Error description
-    ) : DetokenizeResult<T>()
 }
 ```
 
@@ -341,9 +354,10 @@ sealed class BatchTokenizeResult {
         val results: List<BatchTokenItem>, // Individual results
         val summary: BatchTokenizeSummary  // Operation summary
     ) : BatchTokenizeResult()
-    
+
     data class Error(
-        val message: String               // Error description
+        val message: String,               // Error description
+        val httpStatusCode: Int?           // HTTP status code (null for network/SDK errors)
     ) : BatchTokenizeResult()
 }
 
@@ -357,36 +371,8 @@ data class BatchTokenItem(
 
 data class BatchTokenizeSummary(
     val processedCount: Int,    // Total processed
-    val existingCount: Int,     // Already existed  
+    val existingCount: Int,     // Already existed
     val newlyCreatedCount: Int  // Newly created
-)
-```
-
-#### `BatchDetokenizeResult<T>`
-
-```kotlin
-sealed class BatchDetokenizeResult<T> {
-    data class Success<T>(
-        val results: List<BatchDetokenItem<T>>, // Individual results
-        val summary: BatchDetokenizeSummary     // Operation summary
-    ) : BatchDetokenizeResult<T>()
-    
-    data class Error<T>(
-        val message: String                    // Error description
-    ) : BatchDetokenizeResult<T>()
-}
-
-data class BatchDetokenItem<T>(
-    val token: String,
-    val value: T?,
-    val exists: Boolean,
-    val dataType: String?
-)
-
-data class BatchDetokenizeSummary(
-    val processedCount: Int,  // Total processed
-    val foundCount: Int,      // Successfully found
-    val notFoundCount: Int    // Not found
 )
 ```
 
@@ -395,7 +381,7 @@ data class BatchDetokenizeSummary(
 ```kotlin
 enum class LogLevel(val intValue: Int) {
     OFF(0),      // No logging, default value
-    ERROR(1),    // Only errors  
+    ERROR(1),    // Only errors
     INFO(2),     // Errors + Info
     DEBUG(3),    // Errors + Info + Debug
     VERBOSE(4)   // All logs including verbose

--- a/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/ZeroPiiSDK.kt
+++ b/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/ZeroPiiSDK.kt
@@ -290,6 +290,7 @@ class ZeroPiiSDK private constructor(
         private var INSTANCE: ZeroPiiSDK? = null
 
         @JvmStatic
+        @JvmOverloads
         fun initialize(
             tokenProvider: AccessTokenProvider,
             apiUrl: String,

--- a/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/ZeroPiiSDK.kt
+++ b/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/ZeroPiiSDK.kt
@@ -9,6 +9,8 @@ import com.clevertap.android.zeropii.sdk.repository.AccessTokenProviderAuthRepos
 import com.clevertap.android.zeropii.sdk.repository.AuthRepository
 import com.clevertap.android.zeropii.sdk.repository.TokenRepositoryImpl
 import com.clevertap.android.zeropii.sdk.repository.TokenRepository
+import com.clevertap.android.zeropii.sdk.retry.DefaultRetryPolicy
+import com.clevertap.android.zeropii.sdk.retry.RetryPolicy
 import com.clevertap.android.zeropii.sdk.util.TypeConverterRegistry
 import com.clevertap.android.zeropii.sdk.util.ZeroPiiLogger
 import com.clevertap.android.zeropii.sdk.util.toPublicResult
@@ -26,7 +28,8 @@ class ZeroPiiSDK private constructor(
     private val tokenProvider: AccessTokenProvider,
     private val apiUrl: String,
     private val enableEncryption: Boolean,
-    private val logLevel: Int
+    private val logLevel: Int,
+    private val retryPolicy: RetryPolicy
 ) {
     internal var sdkScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     internal lateinit var tokenRepository: TokenRepository
@@ -54,7 +57,7 @@ class ZeroPiiSDK private constructor(
         // Create repositories
         authRepository = AccessTokenProviderAuthRepository(tokenProvider, logger)
 
-        tokenRepository = TokenRepositoryImpl(networkProvider, authRepository, encryptionManager, logger)
+        tokenRepository = TokenRepositoryImpl(networkProvider, authRepository, encryptionManager, logger, retryPolicy)
         logger.d("ZeroPiiSDK initialization complete")
     }
 
@@ -290,14 +293,16 @@ class ZeroPiiSDK private constructor(
         fun initialize(
             tokenProvider: AccessTokenProvider,
             apiUrl: String,
-            logLevel: ZeroPiiLogger.LogLevel = ZeroPiiLogger.LogLevel.OFF
+            logLevel: ZeroPiiLogger.LogLevel = ZeroPiiLogger.LogLevel.OFF,
+            retryPolicy: RetryPolicy = DefaultRetryPolicy()
         ): ZeroPiiSDK {
             return INSTANCE ?: synchronized(this) {
                 INSTANCE ?: ZeroPiiSDK(
                     tokenProvider,
                     apiUrl,
                     enableEncryption = true,
-                    logLevel = logLevel.intValue
+                    logLevel = logLevel.intValue,
+                    retryPolicy = retryPolicy
                 ).also { INSTANCE = it }
             }
         }

--- a/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/model/RepositoryModels.kt
+++ b/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/model/RepositoryModels.kt
@@ -24,8 +24,9 @@ sealed class TokenizeRepoResult {
      * Error during tokenization
      *
      * @property message The error message
+     * @property httpStatusCode HTTP status code from the API response, or null for network errors
      */
-    data class Error(val message: String) : TokenizeRepoResult()
+    data class Error(val message: String, val httpStatusCode: Int? = null) : TokenizeRepoResult()
 }
 
 /**
@@ -48,7 +49,7 @@ sealed class BatchTokenizeRepoResult {
      * Error during batch tokenization
      *
      * @property message The error message
+     * @property httpStatusCode HTTP status code from the API response, or null for network errors
      */
-    data class Error(val message: String) : BatchTokenizeRepoResult()
+    data class Error(val message: String, val httpStatusCode: Int? = null) : BatchTokenizeRepoResult()
 }
-

--- a/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/model/TokenResults.kt
+++ b/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/model/TokenResults.kt
@@ -23,8 +23,9 @@ sealed class TokenizeResult {
      * Error during tokenization
      *
      * @property message The error message
+     * @property httpStatusCode HTTP status code from the API response, or null for network/SDK errors
      */
-    data class Error(val message: String) : TokenizeResult()
+    data class Error(val message: String, val httpStatusCode: Int? = null) : TokenizeResult()
 }
 
 /**
@@ -46,8 +47,9 @@ sealed class BatchTokenizeResult {
      * Error during batch tokenization
      *
      * @property message The error message
+     * @property httpStatusCode HTTP status code from the API response, or null for network/SDK errors
      */
-    data class Error(val message: String) : BatchTokenizeResult()
+    data class Error(val message: String, val httpStatusCode: Int? = null) : BatchTokenizeResult()
 }
 
 /**
@@ -61,4 +63,3 @@ data class BatchTokenItem(
     val newlyCreated: Boolean,
     val dataType: String?
 )
-

--- a/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/repository/AccessTokenProviderAuthRepository.kt
+++ b/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/repository/AccessTokenProviderAuthRepository.kt
@@ -43,11 +43,17 @@ internal class AccessTokenProviderAuthRepository(
             }
 
             logger.d("Requesting new auth token")
-            return refreshAccessToken()
+            return doRefreshToken()
         }
     }
 
     override suspend fun refreshAccessToken(): String {
+        mutex.withLock {
+            return doRefreshToken()
+        }
+    }
+
+    private suspend fun doRefreshToken(): String {
         val tokenInfo = fetchTokenFromProvider()
         processTokenInfo(tokenInfo)
         return accessToken!!

--- a/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/repository/BaseTokenOperation.kt
+++ b/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/repository/BaseTokenOperation.kt
@@ -58,7 +58,7 @@ abstract class BaseTokenOperation<TRequest, TResponse>(
     protected abstract fun getOperationType(): String
     internal open fun validateRequest(request: TRequest) {}
     internal abstract suspend fun makeApiCall(request: TRequest, accessToken: String): Response<*>
-    internal abstract fun createErrorResult(message: String): TResponse
+    internal abstract fun createErrorResult(message: String, httpStatusCode: Int? = null): TResponse
 
     // Helper methods available to subclasses
 

--- a/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/repository/BatchOperations.kt
+++ b/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/repository/BatchOperations.kt
@@ -54,7 +54,7 @@ class BatchTokenizeOperation(
             else -> {
                 val errorMessage = createErrorResponse(response, getOperationType())
                 logger.e(errorMessage)
-                createErrorResult(errorMessage)
+                createErrorResult(message = errorMessage, httpStatusCode = response.code())
             }
         }
     }
@@ -64,15 +64,15 @@ class BatchTokenizeOperation(
         return encryptionStrategy.batchTokenize(api, accessToken, request)
     }
 
-    override fun createErrorResult(message: String): BatchTokenizeRepoResult {
-        return BatchTokenizeRepoResult.Error(message)
+    override fun createErrorResult(message: String, httpStatusCode: Int?): BatchTokenizeRepoResult {
+        return BatchTokenizeRepoResult.Error(message = message, httpStatusCode = httpStatusCode)
     }
 
     private fun processEncryptedResponse(
         response: Response<EncryptedResponse>
     ): BatchTokenizeRepoResult {
         if (!isSuccessfulResponse(response)) {
-            return createErrorResult(createErrorResponse(response, getOperationType()))
+            return createErrorResult(message = createErrorResponse(response, getOperationType()), httpStatusCode = response.code())
         }
 
         val encryptedResponse = response.body()!!

--- a/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/repository/SingleOperations.kt
+++ b/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/repository/SingleOperations.kt
@@ -40,7 +40,7 @@ class SingleTokenizeOperation(
             else -> {
                 val errorMessage = createErrorResponse(response, getOperationType())
                 logger.e(errorMessage)
-                createErrorResult(errorMessage)
+                createErrorResult(message = errorMessage, httpStatusCode = response.code())
             }
         }
     }
@@ -50,13 +50,13 @@ class SingleTokenizeOperation(
         return encryptionStrategy.tokenize(api, accessToken, request)
     }
 
-    override fun createErrorResult(message: String): TokenizeRepoResult {
-        return TokenizeRepoResult.Error(message)
+    override fun createErrorResult(message: String, httpStatusCode: Int?): TokenizeRepoResult {
+        return TokenizeRepoResult.Error(message = message, httpStatusCode = httpStatusCode)
     }
 
     private fun processEncryptedResponse(response: Response<EncryptedResponse>): TokenizeRepoResult {
         if (!isSuccessfulResponse(response)) {
-            return createErrorResult(createErrorResponse(response, getOperationType()))
+            return createErrorResult(message = createErrorResponse(response, getOperationType()), httpStatusCode = response.code())
         }
 
         val encryptedResponse = response.body()!!

--- a/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/repository/TokenRepositoryImpl.kt
+++ b/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/repository/TokenRepositoryImpl.kt
@@ -4,18 +4,20 @@ import com.clevertap.android.zeropii.sdk.encryption.EncryptionManager
 import com.clevertap.android.zeropii.sdk.model.BatchTokenizeRepoResult
 import com.clevertap.android.zeropii.sdk.model.TokenizeRepoResult
 import com.clevertap.android.zeropii.sdk.network.NetworkProvider
+import com.clevertap.android.zeropii.sdk.retry.RetryPolicy
 import com.clevertap.android.zeropii.sdk.util.ZeroPiiLogger
 
 class TokenRepositoryImpl(
     private val networkProvider: NetworkProvider,
     private val authRepository: AuthRepository,
     private val encryptionManager: EncryptionManager,
-    private val logger: ZeroPiiLogger
+    private val logger: ZeroPiiLogger,
+    private val retryPolicy: RetryPolicy
 ) : TokenRepository {
 
     // Utility components initialized lazily
     private val retryHandler by lazy {
-        RetryHandler(authRepository, logger)
+        RetryHandler(authRepository, logger, retryPolicy)
     }
 
     private val responseProcessor by lazy {

--- a/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/repository/Utility.kt
+++ b/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/repository/Utility.kt
@@ -5,46 +5,53 @@ import com.clevertap.android.zeropii.sdk.model.BatchTokenizeResponse
 import com.clevertap.android.zeropii.sdk.model.BatchTokenizeSummary
 import com.clevertap.android.zeropii.sdk.model.TokenizeRepoResult
 import com.clevertap.android.zeropii.sdk.model.TokenizeResponse
+import com.clevertap.android.zeropii.sdk.retry.RetryPolicy
 import com.clevertap.android.zeropii.sdk.util.ZeroPiiLogger
 import kotlinx.coroutines.delay
 import retrofit2.Response
 import java.io.IOException
 
 /**
- * Handles retry logic with exponential backoff for network operations
+ * Handles retry logic for network operations, delegating retry decisions to [RetryPolicy].
+ *
+ * 401 Unauthorized is handled internally (token refresh + one immediate retry) and is
+ * never passed to the [RetryPolicy].
  */
 class RetryHandler(
     private val authRepository: AuthRepository,
     private val logger: ZeroPiiLogger,
-    private val maxRetries: Int = 1,
-    private val initialDelayMs: Long = 1000L
+    private val retryPolicy: RetryPolicy
 ) {
+    private var tokenRefreshed = false
+
     /**
-     * Executes an API call with retry logic and exponential backoff
+     * Executes an API call with retry logic driven by the injected [RetryPolicy].
      */
     suspend fun <T> executeWithRetry(apiCall: suspend () -> Response<T>): Response<T> {
         var attempt = 0
 
-        while (attempt <= maxRetries) {
+        while (true) {
             try {
                 val response = apiCall()
 
                 when (response.code()) {
                     401 -> {
-                        // Authentication error - refresh token and retry immediately
-                        if (attempt < maxRetries) {
+                        // Authentication error — SDK handles internally: refresh token + immediate retry.
+                        // Not delegated to RetryPolicy. Only one token refresh per executeWithRetry call.
+                        if (!tokenRefreshed) {
                             logger.d("401 Unauthorized - refreshing token and retrying immediately (no delay)")
                             authRepository.refreshAccessToken()
-                            attempt++
-                            continue // No delay for authentication issues
+                            tokenRefreshed = true
+                            continue
                         }
                     }
 
-                    500, 502, 503, 504, 429 -> {
-                        // Server errors or rate limiting - retry with delay
-                        if (attempt < maxRetries) {
-                            logger.w("Server error ${response.code()} - retrying after delay")
-                            attempt = retryWithDelay(attempt)
+                    else -> {
+                        if (!response.isSuccessful && retryPolicy.shouldRetry(attempt, response.code())) {
+                            val delayMs = retryPolicy.retryDelayMs(attempt)
+                            logger.w("Server error ${response.code()} - retrying after ${delayMs}ms")
+                            delay(delayMs)
+                            attempt++
                             continue
                         }
                     }
@@ -53,34 +60,21 @@ class RetryHandler(
                 return response
 
             } catch (e: IOException) {
-                // Network errors - retry with delay
-                if (attempt < maxRetries) {
-                    logger.w("Network error - retrying after delay", e)
-                    attempt = retryWithDelay(attempt)
+                // Network error — null status code signals no HTTP response was received.
+                if (retryPolicy.shouldRetry(attempt, null)) {
+                    val delayMs = retryPolicy.retryDelayMs(attempt)
+                    logger.w("Network error - retrying after ${delayMs}ms", e)
+                    delay(delayMs)
+                    attempt++
                     continue
                 }
-                throw Exception("Network error after $maxRetries retries", e)
+                throw Exception("Network error, retries exhausted", e)
             } catch (e: Exception) {
-                // For other exceptions, don't retry - just throw
+                // Non-retryable exception — throw immediately.
                 logger.e("Non-retryable exception occurred: ${e.message}", e)
                 throw e
             }
         }
-        throw Exception("Failed after $maxRetries retries")
-    }
-
-    private suspend fun retryWithDelay(attempt: Int, exception: Exception? = null): Int {
-        val newAttempt = attempt + 1
-        val delayToApply = initialDelayMs * (1 shl newAttempt) // Exponential backoff
-
-        if (exception != null) {
-            logger.d("Waiting ${delayToApply}ms before retry attempt $newAttempt due to exception")
-        } else {
-            logger.d("Waiting ${delayToApply}ms before retry attempt $newAttempt")
-        }
-
-        delay(delayToApply)
-        return newAttempt
     }
 }
 
@@ -105,7 +99,7 @@ class ResponseProcessor(
         } else {
             val errorMessage = getErrorMessage(response, "Tokenization")
             logger.e(errorMessage)
-            TokenizeRepoResult.Error(errorMessage)
+            TokenizeRepoResult.Error(errorMessage, httpStatusCode = response.code())
         }
     }
 
@@ -128,7 +122,7 @@ class ResponseProcessor(
         } else {
             val errorMessage = getErrorMessage(response, "Batch tokenization")
             logger.e(errorMessage)
-            BatchTokenizeRepoResult.Error(errorMessage)
+            BatchTokenizeRepoResult.Error(errorMessage, httpStatusCode = response.code())
         }
     }
 

--- a/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/repository/Utility.kt
+++ b/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/repository/Utility.kt
@@ -22,13 +22,13 @@ class RetryHandler(
     private val logger: ZeroPiiLogger,
     private val retryPolicy: RetryPolicy
 ) {
-    private var tokenRefreshed = false
 
     /**
      * Executes an API call with retry logic driven by the injected [RetryPolicy].
      */
     suspend fun <T> executeWithRetry(apiCall: suspend () -> Response<T>): Response<T> {
         var attempt = 0
+        var tokenRefreshed = false
 
         while (true) {
             try {

--- a/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/retry/DefaultRetryPolicy.kt
+++ b/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/retry/DefaultRetryPolicy.kt
@@ -8,7 +8,7 @@ package com.clevertap.android.zeropii.sdk.retry
  *
  * @param maxRetries Maximum number of retries. Defaults to 1.
  */
-class DefaultRetryPolicy(private val maxRetries: Int = 1) : RetryPolicy {
+internal class DefaultRetryPolicy(private val maxRetries: Int = 1) : RetryPolicy {
 
     private val retryableStatusCodes = setOf(500, 502, 503, 504, 429)
 

--- a/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/retry/DefaultRetryPolicy.kt
+++ b/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/retry/DefaultRetryPolicy.kt
@@ -1,0 +1,24 @@
+package com.clevertap.android.zeropii.sdk.retry
+
+/**
+ * Default retry policy used by the SDK when no custom policy is provided.
+ *
+ * Retries on server errors (500, 502, 503, 504), rate limiting (429), and network
+ * errors (null status code). Uses exponential backoff: 2s, 4s, 8s, …
+ *
+ * @param maxRetries Maximum number of retries. Defaults to 1.
+ */
+class DefaultRetryPolicy(private val maxRetries: Int = 1) : RetryPolicy {
+
+    private val retryableStatusCodes = setOf(500, 502, 503, 504, 429)
+
+    override fun shouldRetry(attempt: Int, httpStatusCode: Int?): Boolean {
+        if (attempt >= maxRetries) return false
+        // null = network error (IOException), always retryable
+        return httpStatusCode == null || httpStatusCode in retryableStatusCodes
+    }
+
+    override fun retryDelayMs(attempt: Int): Long {
+        return 1000L * (1 shl (attempt + 1)) // 2s, 4s, 8s, …
+    }
+}

--- a/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/retry/RetryPolicy.kt
+++ b/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/retry/RetryPolicy.kt
@@ -1,0 +1,39 @@
+package com.clevertap.android.zeropii.sdk.retry
+
+/**
+ * Controls retry behavior for failed tokenization network requests.
+ *
+ * Implement this interface to customize when and how often the SDK retries
+ * failed API calls. Inject your implementation via [com.clevertap.android.zeropii.sdk.ZeroPiiSDK.initialize].
+ *
+ * Note: 401 Unauthorized responses are handled internally by the SDK (token refresh
+ * + immediate retry) and are never passed to this policy.
+ *
+ * @see DefaultRetryPolicy
+ */
+interface RetryPolicy {
+
+    /**
+     * Determines whether the SDK should retry a failed request.
+     *
+     * Called after each failed attempt before the next retry. Return false to stop
+     * retrying and surface the error to the app via the tokenization callback.
+     *
+     * @param attempt 0-based attempt index. 0 = after the first failure (before first retry).
+     * @param httpStatusCode HTTP status code of the failed response.
+     *                       null if the failure was a network error (no HTTP response received,
+     *                       e.g. timeout or no connectivity).
+     * @return true to retry, false to stop and deliver the error to the callback.
+     */
+    fun shouldRetry(attempt: Int, httpStatusCode: Int?): Boolean
+
+    /**
+     * Returns how long to wait before the next retry attempt.
+     *
+     * Only called when [shouldRetry] returns true.
+     *
+     * @param attempt 0-based attempt index (same value passed to [shouldRetry]).
+     * @return delay in milliseconds. Return 0 for an immediate retry.
+     */
+    fun retryDelayMs(attempt: Int): Long
+}

--- a/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/util/ResultConversionUtils.kt
+++ b/clevertap-android-zeropii-sdk/src/main/java/com/clevertap/android/zeropii/sdk/util/ResultConversionUtils.kt
@@ -23,7 +23,7 @@ fun TokenizeRepoResult.toPublicResult(): TokenizeResult {
             dataType = this.dataType
         )
 
-        is TokenizeRepoResult.Error -> TokenizeResult.Error(this.message)
+        is TokenizeRepoResult.Error -> TokenizeResult.Error(this.message, this.httpStatusCode)
     }
 }
 
@@ -57,6 +57,6 @@ fun BatchTokenizeRepoResult.toPublicResult(): BatchTokenizeResult {
             }
         }
 
-        is BatchTokenizeRepoResult.Error -> BatchTokenizeResult.Error(this.message)
+        is BatchTokenizeRepoResult.Error -> BatchTokenizeResult.Error(this.message, this.httpStatusCode)
     }
 }

--- a/clevertap-android-zeropii-sdk/src/test/java/com/clevertap/android/zeropii/sdk/repository/RetryHandlerTest.kt
+++ b/clevertap-android-zeropii-sdk/src/test/java/com/clevertap/android/zeropii/sdk/repository/RetryHandlerTest.kt
@@ -1,5 +1,7 @@
 package com.clevertap.android.zeropii.sdk.repository
 
+import com.clevertap.android.zeropii.sdk.retry.DefaultRetryPolicy
+import com.clevertap.android.zeropii.sdk.retry.RetryPolicy
 import com.clevertap.android.zeropii.sdk.util.ZeroPiiLogger
 import io.mockk.Called
 import io.mockk.Runs
@@ -53,7 +55,7 @@ class RetryHandlerSuccessfulCallTest(
     fun setUp() {
         mockAuthRepository = mockk(relaxed = true)
         mockLogger = mockk(relaxed = true)
-        retryHandler = RetryHandler(mockAuthRepository, mockLogger, maxRetries = 2)
+        retryHandler = RetryHandler(mockAuthRepository, mockLogger, DefaultRetryPolicy(maxRetries = 2))
     }
 
     @Test
@@ -85,7 +87,7 @@ class RetryHandler401Test {
     fun setUp() {
         mockAuthRepository = mockk(relaxed = true)
         mockLogger = mockk(relaxed = true)
-        retryHandler = RetryHandler(mockAuthRepository, mockLogger, maxRetries = 2)
+        retryHandler = RetryHandler(mockAuthRepository, mockLogger, DefaultRetryPolicy(maxRetries = 2))
     }
 
     @Test
@@ -108,8 +110,8 @@ class RetryHandler401Test {
     }
 
     @Test
-    fun shouldFailAfterMaxRetriesOn401() = runTest {
-        // Arrange
+    fun shouldReturnErrorAfterSingleTokenRefreshOn401() = runTest {
+        // Arrange: both attempts return 401
         val unauthorizedResponse = Response.error<String>(401, ResponseBody.create(null,"Unauthorized"))
         val apiCall: suspend () -> Response<String> = mockk()
 
@@ -119,14 +121,14 @@ class RetryHandler401Test {
         // Act
         val result = retryHandler.executeWithRetry(apiCall)
 
-        // Assert
+        // Assert: Only one token refresh per executeWithRetry call
         assertEquals(
-            "Should return last 401 response after max retries",
+            "Should return 401 after single token refresh attempt",
             unauthorizedResponse,
             result
         )
-        coVerify(exactly = 3) { apiCall() } // Initial + 2 retries
-        coVerify(exactly = 2) { mockAuthRepository.refreshAccessToken() }
+        coVerify(exactly = 2) { apiCall() } // Initial + 1 retry after refresh
+        coVerify(exactly = 1) { mockAuthRepository.refreshAccessToken() }
     }
 
     @Test
@@ -184,7 +186,7 @@ class RetryHandlerNonRetryableExceptionTest(
     fun setUp() {
         mockAuthRepository = mockk(relaxed = true)
         mockLogger = mockk(relaxed = true)
-        retryHandler = RetryHandler(mockAuthRepository, mockLogger, maxRetries = 2)
+        retryHandler = RetryHandler(mockAuthRepository, mockLogger, DefaultRetryPolicy(maxRetries = 2))
     }
 
     @Test
@@ -219,7 +221,7 @@ class RetryHandlerComplexScenarioTest {
         mockAuthRepository = mockk(relaxed = true)
         mockLogger = mockk(relaxed = true)
         retryHandler =
-            RetryHandler(mockAuthRepository, mockLogger, maxRetries = 3, initialDelayMs = 50L)
+            RetryHandler(mockAuthRepository, mockLogger, DefaultRetryPolicy(maxRetries = 3))
     }
 
     @Test
@@ -286,7 +288,7 @@ class RetryHandlerEdgeCaseTest {
     @Test
     fun shouldHandleZeroMaxRetries() = runTest {
         // Arrange
-        val retryHandler = RetryHandler(mockAuthRepository, mockLogger, maxRetries = 0)
+        val retryHandler = RetryHandler(mockAuthRepository, mockLogger, DefaultRetryPolicy(maxRetries = 0))
         val errorResponse = Response.error<String>(500, ResponseBody.create(null,"Server Error"))
         val apiCall: suspend () -> Response<String> = mockk()
 
@@ -355,7 +357,18 @@ class RetryHandlerServerErrorDelayTest(
     fun setUp() {
         mockAuthRepository = mockk(relaxed = true)
         mockLogger = mockk(relaxed = true)
-        retryHandler = RetryHandler(mockAuthRepository, mockLogger, maxRetries, initialDelayMs)
+
+        // Use a custom RetryPolicy that mirrors the parameterized initialDelayMs
+        val customPolicy = object : RetryPolicy {
+            override fun shouldRetry(attempt: Int, httpStatusCode: Int?): Boolean {
+                if (attempt >= maxRetries) return false
+                return httpStatusCode == null || httpStatusCode in setOf(500, 502, 503, 504, 429)
+            }
+            override fun retryDelayMs(attempt: Int): Long {
+                return initialDelayMs * (1 shl (attempt + 1))
+            }
+        }
+        retryHandler = RetryHandler(mockAuthRepository, mockLogger, customPolicy)
 
         // Mock the delay function to avoid actual waiting
         mockkStatic("kotlinx.coroutines.DelayKt")
@@ -408,7 +421,7 @@ class RetryHandlerNetworkErrorDelayTest {
         mockAuthRepository = mockk(relaxed = true)
         mockLogger = mockk(relaxed = true)
         retryHandler =
-            RetryHandler(mockAuthRepository, mockLogger, maxRetries = 2, initialDelayMs = 1000L)
+            RetryHandler(mockAuthRepository, mockLogger, DefaultRetryPolicy(maxRetries = 2))
 
         mockkStatic("kotlinx.coroutines.DelayKt")
         coEvery { kotlinx.coroutines.delay(any(Long::class)) } just Runs
@@ -475,7 +488,7 @@ class RetryHandler401NoDelayTest {
     fun setUp() {
         mockAuthRepository = mockk(relaxed = true)
         mockLogger = mockk(relaxed = true)
-        retryHandler = RetryHandler(mockAuthRepository, mockLogger, maxRetries = 2, initialDelayMs = 1000L)
+        retryHandler = RetryHandler(mockAuthRepository, mockLogger, DefaultRetryPolicy(maxRetries = 2))
 
         mockkStatic("kotlinx.coroutines.DelayKt")
         coEvery { kotlinx.coroutines.delay(any(Long::class)) } just Runs
@@ -504,13 +517,13 @@ class RetryHandler401NoDelayTest {
         coVerify(exactly = 2) { apiCall() }
         coVerify(exactly = 1) { mockAuthRepository.refreshAccessToken() }
 
-        // ✅ Critical: Verify delay was NEVER called for 401 errors
+        // Critical: Verify delay was NEVER called for 401 errors
         coVerify(exactly = 0) { kotlinx.coroutines.delay(any(Long::class)) }
 
     }
 
     @Test
-    fun shouldNotDelayOn401EvenWithMultipleRetries() = runTest {
+    fun shouldNotDelayOn401EvenWhenBothAttemptsReturn401() = runTest {
         // Arrange
         val unauthorizedResponse = Response.error<String>(401, ResponseBody.create(null,"Unauthorized"))
         val apiCall: suspend () -> Response<String> = mockk()
@@ -521,12 +534,55 @@ class RetryHandler401NoDelayTest {
         // Act
         val result = retryHandler.executeWithRetry(apiCall)
 
-        // Assert
-        assertEquals("Should return 401 after max retries", unauthorizedResponse, result)
-        coVerify(exactly = 3) { apiCall() } // Initial + 2 retries
-        coVerify(exactly = 2) { mockAuthRepository.refreshAccessToken() }
+        // Assert: Only one token refresh per executeWithRetry call
+        assertEquals("Should return 401 after single token refresh", unauthorizedResponse, result)
+        coVerify(exactly = 2) { apiCall() } // Initial + 1 retry after refresh
+        coVerify(exactly = 1) { mockAuthRepository.refreshAccessToken() }
 
-        // ✅ Still no delay calls even with multiple 401s
+        // Still no delay calls for 401s
         coVerify(exactly = 0) { kotlinx.coroutines.delay(any(Long::class)) }
+    }
+}
+
+// ====================================
+// tokenRefreshed Reset Tests (Bug Fix Verification)
+// ====================================
+class RetryHandlerTokenRefreshResetTest {
+    private lateinit var mockAuthRepository: AuthRepository
+    private lateinit var mockLogger: ZeroPiiLogger
+    private lateinit var retryHandler: RetryHandler
+
+    @Before
+    fun setUp() {
+        mockAuthRepository = mockk(relaxed = true)
+        mockLogger = mockk(relaxed = true)
+        retryHandler = RetryHandler(mockAuthRepository, mockLogger, DefaultRetryPolicy(maxRetries = 1))
+    }
+
+    @Test
+    fun shouldRefreshTokenOnSecondExecuteWithRetryCallAfterFirst401() = runTest {
+        // Arrange: First call gets 401 then succeeds
+        val unauthorizedResponse = Response.error<String>(401, ResponseBody.create(null, "Unauthorized"))
+        val successResponse = Response.success("Success")
+
+        coEvery { mockAuthRepository.refreshAccessToken() } returns "new-token"
+
+        // First executeWithRetry call: 401 → refresh → success
+        val apiCall1: suspend () -> Response<String> = mockk()
+        coEvery { apiCall1() } returnsMany listOf(unauthorizedResponse, successResponse)
+
+        val result1 = retryHandler.executeWithRetry(apiCall1)
+        assertEquals(successResponse, result1)
+        coVerify(exactly = 1) { mockAuthRepository.refreshAccessToken() }
+
+        // Second executeWithRetry call: also gets 401 — tokenRefreshed should be reset
+        val apiCall2: suspend () -> Response<String> = mockk()
+        coEvery { apiCall2() } returnsMany listOf(unauthorizedResponse, successResponse)
+
+        val result2 = retryHandler.executeWithRetry(apiCall2)
+        assertEquals(successResponse, result2)
+
+        // Verify token was refreshed AGAIN for the second call
+        coVerify(exactly = 2) { mockAuthRepository.refreshAccessToken() }
     }
 }


### PR DESCRIPTION
### 🔄 Pluggable Retry Policy (SDK-5582)
- New `RetryPolicy` interface with `shouldRetry()` and `retryDelayMs()` methods
- Built-in exponential backoff policy (internal, not exposed)
- Apps can inject custom retry logic via `initialize(retryPolicy = ...)`
- 401 handling remains internal (automatic token refresh + immediate retry)
### 📊 Enhanced Error Observability (SDK-5582)
- Added `httpStatusCode: Int?` to all error result classes
  - `null` = network error (timeout, no connectivity)
  - Non-null = HTTP response received with that status
- Enables intelligent error handling and debugging

### 📚 Documentation Updates
- Comprehensive README.md rewrite with new API surface
- Removed all detokenization examples
- Added `AccessTokenProvider` implementation guide
- Added custom `RetryPolicy` example (LinearRetryPolicy)
- Updated initialization examples and API reference